### PR TITLE
added tests for fcReadFields

### DIFF
--- a/oneflux_steps/ustar_cp/fcReadFields.m
+++ b/oneflux_steps/ustar_cp/fcReadFields.m
@@ -1,23 +1,104 @@
-	function x = fcReadFields(s,FieldName); 
-		
-	nd=ndims(s); ns=size(s); x=NaN*ones(ns); 
-	
-	switch nd; 
-		case 2; 
-			for i=1:ns(1); 
-				for j=1:ns(2); 
-					tmp=getfield(s,{i,j},FieldName); 
-					if ~isempty(tmp); x(i,j)=tmp; end;
-				end; 
-			end; 
-		case 3; 
-			for i=1:ns(1); 
-				for j=1:ns(2); 
-					for k=1:ns(3); 
-						tmp=getfield(s,{i,j,k},FieldName); 
-						if ~isempty(tmp); x(i,j,k)=tmp; end; 
-					end;
-				end;
-			end;
-		otherwise; 
-	end; 
+function x = fcReadFields(stats, FieldName, varargin)
+
+	s = [];
+
+	if nargin > 2 && any(strcmp(varargin, 'jsondecode'))
+		s = jsondecode(stats);
+	else
+		s = stats; % Assume stats is already a struct
+	end
+
+	if isempty(s)
+		error('Decoded structure is empty. Check the JSON format.');
+	end
+
+    % Initialize output
+    nd = ndims(s); 
+    ns = size(s); 
+    x = NaN * ones(ns); 
+    
+    % Handle 2D and 3D arrays
+    switch nd
+        case 2
+            for i = 1:ns(1)
+                for j = 1:ns(2)
+                    try
+                        tmp = getfield(s, {i, j}, FieldName); 
+                        if ~isempty(tmp)
+                            x(i, j) = tmp;
+                        end
+                    catch
+                        % Field not found
+                    end
+                end
+            end
+        case 3
+            for i = 1:ns(1)
+                for j = 1:ns(2)
+                    for k = 1:ns(3)
+                        try
+                            tmp = getfield(s, {i, j, k}, FieldName); 
+                            if ~isempty(tmp)
+                                x(i, j, k) = tmp;
+                            end
+                        catch
+                            % Field not found
+                        end
+                    end
+                end
+            end
+    end
+end
+
+
+function stats = jsonToStats(jsonStr)
+    % Decode the JSON string into a MATLAB structure array
+    decodedStats = jsondecode(jsonStr);
+
+    % Define the template structure
+    statsTemplate = struct(...
+        'n', NaN, 'Cp', NaN, 'Fmax', NaN, 'p', NaN, ...
+        'b0', NaN, 'b1', NaN, 'b2', NaN, 'c2', NaN, ...
+        'cib0', NaN, 'cib1', NaN, 'cic2', NaN, ...
+        'mt', NaN, 'ti', NaN, 'tf', NaN, ...
+        'ruStarVsT', NaN, 'puStarVsT', NaN, ...
+        'mT', NaN, 'ciT', NaN ...
+    );
+
+    % Ensure decodedStats is a struct
+    if ~isstruct(decodedStats)
+        error('Invalid JSON format: expected a structure.');
+    end
+
+    % Determine structure size
+    dataSize = size(decodedStats);
+
+    % Preallocate the stats structure
+    stats = repmat(statsTemplate, dataSize);
+
+    % Populate stats structure with error handling
+    for i = 1:dataSize(1)
+        for j = 1:dataSize(2)
+            for k = 1:max(1, dataSize(3))
+                if isfield(decodedStats, 'n') && ~isempty(decodedStats(i, j, k))
+                    stats(i, j, k) = mergeStructures(statsTemplate, decodedStats(i, j, k));
+                else
+                    stats(i, j, k) = statsTemplate; % Use default if not filled
+                end
+            end
+        end
+    end
+end
+
+function outStruct = mergeStructures(template, inputStruct)
+    fields = fieldnames(template);
+
+    for f = 1:numel(fields)
+        fieldName = fields{f};
+        if isfield(inputStruct, fieldName) && ~isempty(inputStruct.(fieldName))
+            outStruct.(fieldName) = inputStruct.(fieldName);
+        else
+            outStruct.(fieldName) = template.(fieldName); % Default if missing
+        end
+    end
+end

--- a/oneflux_steps/ustar_cp/fcReadFields.m
+++ b/oneflux_steps/ustar_cp/fcReadFields.m
@@ -1,17 +1,5 @@
 function x = fcReadFields(stats, FieldName, varargin)
 
-	s = [];
-
-	if nargin > 2 && any(strcmp(varargin, 'jsondecode'))
-		s = jsondecode(stats);
-	else
-		s = stats; % Assume stats is already a struct
-	end
-
-	if isempty(s)
-		error('Decoded structure is empty. Check the JSON format.');
-	end
-
     % Initialize output
     nd = ndims(s); 
     ns = size(s); 
@@ -47,58 +35,5 @@ function x = fcReadFields(stats, FieldName, varargin)
                     end
                 end
             end
-    end
-end
-
-
-function stats = jsonToStats(jsonStr)
-    % Decode the JSON string into a MATLAB structure array
-    decodedStats = jsondecode(jsonStr);
-
-    % Define the template structure
-    statsTemplate = struct(...
-        'n', NaN, 'Cp', NaN, 'Fmax', NaN, 'p', NaN, ...
-        'b0', NaN, 'b1', NaN, 'b2', NaN, 'c2', NaN, ...
-        'cib0', NaN, 'cib1', NaN, 'cic2', NaN, ...
-        'mt', NaN, 'ti', NaN, 'tf', NaN, ...
-        'ruStarVsT', NaN, 'puStarVsT', NaN, ...
-        'mT', NaN, 'ciT', NaN ...
-    );
-
-    % Ensure decodedStats is a struct
-    if ~isstruct(decodedStats)
-        error('Invalid JSON format: expected a structure.');
-    end
-
-    % Determine structure size
-    dataSize = size(decodedStats);
-
-    % Preallocate the stats structure
-    stats = repmat(statsTemplate, dataSize);
-
-    % Populate stats structure with error handling
-    for i = 1:dataSize(1)
-        for j = 1:dataSize(2)
-            for k = 1:max(1, dataSize(3))
-                if isfield(decodedStats, 'n') && ~isempty(decodedStats(i, j, k))
-                    stats(i, j, k) = mergeStructures(statsTemplate, decodedStats(i, j, k));
-                else
-                    stats(i, j, k) = statsTemplate; % Use default if not filled
-                end
-            end
-        end
-    end
-end
-
-function outStruct = mergeStructures(template, inputStruct)
-    fields = fieldnames(template);
-
-    for f = 1:numel(fields)
-        fieldName = fields{f};
-        if isfield(inputStruct, fieldName) && ~isempty(inputStruct.(fieldName))
-            outStruct.(fieldName) = inputStruct.(fieldName);
-        else
-            outStruct.(fieldName) = template.(fieldName); % Default if missing
-        end
     end
 end

--- a/oneflux_steps/ustar_cp/fcReadFields.m
+++ b/oneflux_steps/ustar_cp/fcReadFields.m
@@ -1,39 +1,23 @@
-function x = fcReadFields(stats, FieldName, varargin)
-
-    % Initialize output
-    nd = ndims(s); 
-    ns = size(s); 
-    x = NaN * ones(ns); 
-    
-    % Handle 2D and 3D arrays
-    switch nd
-        case 2
-            for i = 1:ns(1)
-                for j = 1:ns(2)
-                    try
-                        tmp = getfield(s, {i, j}, FieldName); 
-                        if ~isempty(tmp)
-                            x(i, j) = tmp;
-                        end
-                    catch
-                        % Field not found
-                    end
-                end
-            end
-        case 3
-            for i = 1:ns(1)
-                for j = 1:ns(2)
-                    for k = 1:ns(3)
-                        try
-                            tmp = getfield(s, {i, j, k}, FieldName); 
-                            if ~isempty(tmp)
-                                x(i, j, k) = tmp;
-                            end
-                        catch
-                            % Field not found
-                        end
-                    end
-                end
-            end
-    end
-end
+	function x = fcReadFields(s,FieldName); 
+		
+	nd=ndims(s); ns=size(s); x=NaN*ones(ns); 
+	
+	switch nd; 
+		case 2; 
+			for i=1:ns(1); 
+				for j=1:ns(2); 
+					tmp=getfield(s,{i,j},FieldName); 
+					if ~isempty(tmp); x(i,j)=tmp; end;
+				end; 
+			end; 
+		case 3; 
+			for i=1:ns(1); 
+				for j=1:ns(2); 
+					for k=1:ns(3); 
+						tmp=getfield(s,{i,j,k},FieldName); 
+						if ~isempty(tmp); x(i,j,k)=tmp; end; 
+					end;
+				end;
+			end;
+		otherwise; 
+	end; 

--- a/oneflux_steps/ustar_cp_refactor_wip/fcReadFields.m
+++ b/oneflux_steps/ustar_cp_refactor_wip/fcReadFields.m
@@ -1,4 +1,16 @@
-	function x = fcReadFields(s,FieldName); 
+	function x = fcReadFields(stats, FieldName, varargin);
+
+		s = [];
+
+		if nargin > 2 && any(strcmp(varargin, 'jsondecode'))
+			s = jsondecode(stats);
+		else
+			s = stats; % Assume stats is already a struct
+		end
+	
+		if isempty(s)
+			error('Decoded structure is empty. Check the JSON format.');
+		end
 		
 	nd=ndims(s); ns=size(s); x=NaN*ones(ns); 
 	

--- a/tests/unit_tests/test_ustar_cp/test_fcReadFields.py
+++ b/tests/unit_tests/test_ustar_cp/test_fcReadFields.py
@@ -1,0 +1,65 @@
+import pytest
+import matlab.engine
+import numpy as np
+
+@pytest.fixture
+def sample_stats_json(matlab_engine):
+    """Create a JSON-encoded single-entry MATLAB-compatible stats struct."""
+    stats_entry = {
+        "n": 1.0, "Cp": float("nan"), "Fmax": float("nan"), "p": float("nan"),
+        "b0": float("nan"), "b1": float("nan"), "b2": float("nan"), "c2": float("nan"),
+        "cib0": float("nan"), "cib1": float("nan"), "cic2": float("nan"),
+        "mt": float("nan"), "ti": float("nan"), "tf": float("nan"),
+        "ruStarVsT": float("nan"), "puStarVsT": float("nan"),
+        "mT": float("nan"), "ciT": float("nan")
+    }
+    return matlab_engine.jsonencode(stats_entry)
+
+@pytest.fixture
+def multi_stats_json(matlab_engine):
+    """Create a multi-entry JSON representation of the stats structure."""
+    stats_entry = {
+        "n": 1.0, "Cp": float("nan"), "Fmax": float("nan"), "p": float("nan"),
+        "b0": float("nan"), "b1": float("nan"), "b2": float("nan"), "c2": float("nan"),
+        "cib0": float("nan"), "cib1": float("nan"), "cic2": float("nan"),
+        "mt": float("nan"), "ti": float("nan"), "tf": float("nan"),
+        "ruStarVsT": float("nan"), "puStarVsT": float("nan"),
+        "mT": float("nan"), "ciT": float("nan")
+    }
+
+    multi_stats = [[[stats_entry, stats_entry], [stats_entry, stats_entry]], 
+                   [[stats_entry, stats_entry], [stats_entry, stats_entry]]]
+    return matlab_engine.jsonencode(multi_stats)
+
+@pytest.mark.parametrize(
+    "field_name, expected",
+    [
+        ("n", [[1.0]]), 
+        ("Cp", [[np.nan]])
+    ]
+)
+def test_fcReadFields_valid(matlab_engine, sample_stats_json, field_name, expected):
+    """Test fcReadFields with a single-entry JSON."""
+    result = matlab_engine.fcReadFields(sample_stats_json, field_name, 'jsondecode', 1)
+    assert np.allclose(result, expected, equal_nan=True), f"Expected {expected}, got {result}"
+
+@pytest.mark.parametrize(
+    "field_name, expected",
+    [
+        ("n", [[[1.0, 1.0], [1.0, 1.0]], [[1.0, 1.0], [1.0, 1.0]]]),
+        ("Cp", [[[np.nan, np.nan], [np.nan, np.nan]], 
+                [[np.nan, np.nan], [np.nan, np.nan]]]),
+    ]
+)
+def test_fcReadFields_multi(matlab_engine, multi_stats_json, field_name, expected):
+    """Test fcReadFields with a multi-entry JSON."""
+    result = matlab_engine.fcReadFields(multi_stats_json, field_name, 'jsondecode', 1)
+
+    # Convert MATLAB result
+    if isinstance(result, matlab.double):
+        result_list = [[[float(cell) if not np.isnan(cell) else float("nan") 
+                         for cell in row] for row in layer] for layer in result]
+    else:
+        pytest.fail(f"Unexpected MATLAB result type: {type(result)}")
+
+    assert np.allclose(result_list, expected, equal_nan=True), f"Expected {expected}, got {result_list}"


### PR DESCRIPTION
closes #78 

This PR adds tests for the fcReadFields.m function.

Minor refactoring of fcReadFields.m was required to enable testing.

Tests cover basic functionality.

More extensive testing of edge/failure cases is difficult due to lack of facility in function to fail gracefully.

This function takes a multidimensional arrangement of the basic `statsMT` set of fields, and a specific field as args, then returns the values associated with that field in the same format as the multidimensional array.