### PR TITLE
Move differential tests into their own files

### DIFF
--- a/tests/unit_tests/test_ustar_cp/test_differential_cpdEvaluateUStarTh4Season20100901.py
+++ b/tests/unit_tests/test_ustar_cp/test_differential_cpdEvaluateUStarTh4Season20100901.py
@@ -1,5 +1,6 @@
 """
-Test module for the cpdEvaluateUStarTh4Season20100901 matlab function.
+Test module for the cpdEvaluateUStarTh4Season20100901.
+Differential tests between the MATLAB and Python code.
 
 This module contains the unit tests for the cpdEvaluateUStarTh4Season20100901. 
 These tests cover basic behaviour, edge cases and errors.

--- a/tests/unit_tests/test_ustar_cp/test_differential_fcDatevec.py
+++ b/tests/unit_tests/test_ustar_cp/test_differential_fcDatevec.py
@@ -1,0 +1,34 @@
+"""
+Differential tests for MATLAB and Python of fcDatevec function
+"""
+from hypothesis import given, settings
+from hypothesis.strategies import floats, lists
+from oneflux_steps.ustar_cp_python.fcDatevec import fcDatevec
+import pandas as pd
+
+# Property-based tests for fcDatevec
+# The size of the input `n` determines the size of the output as `n x 6`
+@given(data=lists(floats(allow_infinity=False, min_value=-10000, max_value=10000), min_size=1, max_size=100))
+@settings(deadline=1000)
+def test_differential(test_engine, data):
+    # Call the function
+    result = test_engine.fcDatevec(test_engine.convert(data),nargout=6)
+
+    # Compare matlab and python
+    py_result = fcDatevec(data)
+    assert test_engine.equal(result, test_engine.convert(py_result))
+
+# TODO: During migration remove this differential test
+def test_fcDatevec_site_data_differential(test_engine):
+
+    time_artifact_path = 'tests/test_artifacts/cpdEvaluateUStarTh4Season20100901_artifacts/CA-Cbo_qca_ustar_2007/input_time_it_.csv'
+    data = pd.read_csv(time_artifact_path, header=None).values.tolist()
+
+    # Call the function
+    expected_result = test_engine.fcDatevec(test_engine.convert(data), nargout=6)
+
+    print("test_engine.fcDatevec(test_engine.convert(data), nargout=6) has run...\n\n")
+
+    result = fcDatevec(data)
+
+    assert test_engine.equal(result, expected_result)

--- a/tests/unit_tests/test_ustar_cp/test_differential_stats.py
+++ b/tests/unit_tests/test_ustar_cp/test_differential_stats.py
@@ -1,0 +1,63 @@
+"""
+Differential test between MATLAB and Python function for setup_Stats
+"""
+
+import pytest
+import numpy as np
+
+nan = np.nan
+
+# TODO: remove differential tests
+stats_entry = {'n': nan, 'Cp': nan, 'Fmax': nan, 'p': nan, 'b0': nan, 'b1': nan, 'b2': nan, 'c2': nan, 'cib0': nan, 'cib1': nan, 'cic2': nan, 'mt': nan, 'ti': nan, 'tf': nan, 'ruStarVsT': nan, 'puStarVsT': nan, 'mT': nan, 'ciT': nan}
+# Test for the setup_Stats function
+@pytest.mark.parametrize(
+    "nBoot, nSeasons, nStrataX, expected_shape",
+    [
+        # Case 1: Basic 2x2x2 array
+        (2, 2, 2, ([[[stats_entry, stats_entry],[stats_entry,stats_entry]],[[stats_entry,stats_entry],[stats_entry,stats_entry]]])),
+
+        # TODO: check whether we need these tests
+        # Case 2a: Single season, single strata, single boot
+        #(1, 1, 1, stats_entry),
+
+        # Case 3: No bootstrap iterations (nBoot=0)
+        #(0, 2, 3, stats_entry),
+    ]
+)
+def test_setup_Stats_differential(test_engine, nBoot, nSeasons, nStrataX, expected_shape):
+    # Call the MATLAB function
+    Stats= test_engine.setup_Stats(nBoot, nSeasons, nStrataX, jsonencode=[0])
+    # Call the python function
+    import oneflux_steps.ustar_cp_python.cpdBootstrap as cpdBootstrap
+    Stats_python = cpdBootstrap.setup_Stats(nBoot, nSeasons, nStrataX)
+
+    assert_dicts_with_nan_equal(Stats_python, expected_shape)
+
+def assert_dicts_with_nan_equal(obj1, obj2) -> None:
+    """
+    Recursively assert equality between dictionaries, lists of dictionaries, or nested lists containing dictionaries,
+    considering NaN values.
+
+    Args:
+        obj1 (Any): First object (dict, list, or nested structure).
+        obj2 (Any): Second object (dict, list, or nested structure).
+
+    Raises:
+        AssertionError: If the objects or nested contents are not equal.
+    """
+    if isinstance(obj1, dict) and isinstance(obj2, dict):
+        assert obj1.keys() == obj2.keys(), "Dictionaries have different keys."
+        for key in obj1:
+            val1, val2 = obj1[key], obj2[key]
+            if isinstance(val1, float) and isinstance(val2, float):
+                assert np.isnan(val1) and np.isnan(val2) or val1 == val2, f"Mismatch at key {key}: {val1} != {val2}"
+            else:
+                assert_dicts_with_nan_equal(val1, val2)
+
+    elif isinstance(obj1, list) and isinstance(obj2, list):
+        assert len(obj1) == len(obj2), "Lists have different lengths."
+        for item1, item2 in zip(obj1, obj2):
+            assert_dicts_with_nan_equal(item1, item2)
+
+    else:
+        assert obj1 == obj2, f"Mismatch in items: {obj1} != {obj2}"

--- a/tests/unit_tests/test_ustar_cp/test_fcDatevec.py
+++ b/tests/unit_tests/test_ustar_cp/test_fcDatevec.py
@@ -14,19 +14,6 @@ import pandas as pd
 # The size of the input `n` determines the size of the output as `n x 6`
 @given(data=lists(floats(allow_infinity=False, min_value=-10000, max_value=10000), min_size=1, max_size=100))
 @settings(deadline=1000)
-def test_differential(test_engine, data):
-    # Call the function
-    result = test_engine.fcDatevec(test_engine.convert(data),nargout=6)
-
-    # Compare matlab and python
-    py_result = fcDatevec(data)
-    assert test_engine.equal(result, test_engine.convert(py_result))
-
-
-# Property-based tests for fcDatevec
-# The size of the input `n` determines the size of the output as `n x 6`
-@given(data=lists(floats(allow_infinity=False, min_value=-10000, max_value=10000), min_size=1, max_size=100))
-@settings(deadline=1000)
 def test_fcDatevec_shape(test_engine, data):
     """
     Test the shape of the output of fcDatevec
@@ -83,18 +70,3 @@ def test_fcDatevec_specific(test_engine, t, expected):
 
     # Check the result
     assert test_engine.equal(result, test_engine.convert(expected))
-
-# TODO: During migration remove this differential test
-def test_fcDatevec_site_data_differential(test_engine):
-
-    time_artifact_path = 'tests/test_artifacts/cpdEvaluateUStarTh4Season20100901_artifacts/CA-Cbo_qca_ustar_2007/input_time_it_.csv'
-    data = pd.read_csv(time_artifact_path, header=None).values.tolist()
-
-    # Call the function
-    expected_result = test_engine.fcDatevec(test_engine.convert(data), nargout=6)
-
-    print("test_engine.fcDatevec(test_engine.convert(data), nargout=6) has run...\n\n")
-
-    result = fcDatevec(data)
-
-    assert test_engine.equal(result, expected_result)

--- a/tests/unit_tests/test_ustar_cp/test_stats.py
+++ b/tests/unit_tests/test_ustar_cp/test_stats.py
@@ -18,7 +18,6 @@ def test_generate_statsMT(test_engine):
         assert field in StatsMT, f"Missing field: {field}"  # Access fields like dict keys
         assert np.isnan(StatsMT[field]), f"Field {field} is not NaN"
 
-# TODO: remove differential tests
 stats_entry = {'n': nan, 'Cp': nan, 'Fmax': nan, 'p': nan, 'b0': nan, 'b1': nan, 'b2': nan, 'c2': nan, 'cib0': nan, 'cib1': nan, 'cic2': nan, 'mt': nan, 'ti': nan, 'tf': nan, 'ruStarVsT': nan, 'puStarVsT': nan, 'mT': nan, 'ciT': nan}
 # Test for the setup_Stats function
 @pytest.mark.parametrize(
@@ -29,49 +28,14 @@ stats_entry = {'n': nan, 'Cp': nan, 'Fmax': nan, 'p': nan, 'b0': nan, 'b1': nan,
 
         # TODO: check whether we need these tests
         # Case 2a: Single season, single strata, single boot
-        #(1, 1, 1, stats_entry),
+        # (1, 1, 1, stats_entry),
 
         # Case 3: No bootstrap iterations (nBoot=0)
-        #(0, 2, 3, stats_entry),
+        # (0, 2, 3, stats_entry),
     ]
 )
-def test_setup_Stats_differential(test_engine, nBoot, nSeasons, nStrataX, expected_shape):
+def test_setup_Stats(test_engine, nBoot, nSeasons, nStrataX, expected_shape):
     # Call the MATLAB function
     Stats= test_engine.setup_Stats(nBoot, nSeasons, nStrataX, jsonencode=[0])
 
     assert test_engine.equal(Stats, expected_shape)
-
-    # Call the python function
-    import oneflux_steps.ustar_cp_python.cpdBootstrap as cpdBootstrap
-    Stats_python = cpdBootstrap.setup_Stats(nBoot, nSeasons, nStrataX)
-
-    assert_dicts_with_nan_equal(Stats_python, expected_shape)
-
-def assert_dicts_with_nan_equal(obj1, obj2) -> None:
-    """
-    Recursively assert equality between dictionaries, lists of dictionaries, or nested lists containing dictionaries,
-    considering NaN values.
-
-    Args:
-        obj1 (Any): First object (dict, list, or nested structure).
-        obj2 (Any): Second object (dict, list, or nested structure).
-
-    Raises:
-        AssertionError: If the objects or nested contents are not equal.
-    """
-    if isinstance(obj1, dict) and isinstance(obj2, dict):
-        assert obj1.keys() == obj2.keys(), "Dictionaries have different keys."
-        for key in obj1:
-            val1, val2 = obj1[key], obj2[key]
-            if isinstance(val1, float) and isinstance(val2, float):
-                assert np.isnan(val1) and np.isnan(val2) or val1 == val2, f"Mismatch at key {key}: {val1} != {val2}"
-            else:
-                assert_dicts_with_nan_equal(val1, val2)
-
-    elif isinstance(obj1, list) and isinstance(obj2, list):
-        assert len(obj1) == len(obj2), "Lists have different lengths."
-        for item1, item2 in zip(obj1, obj2):
-            assert_dicts_with_nan_equal(item1, item2)
-
-    else:
-        assert obj1 == obj2, f"Mismatch in items: {obj1} != {obj2}"


### PR DESCRIPTION
Preserves the test functionality but just moves any differential tests into files named with the form `test_differential_*.py` so it's easier to remove them in the future. 