### PR TITLE
Fix fcEqnAnnualSine tests

### DIFF
--- a/tests/unit_tests/test_ustar_cp/test_fcEqnAnnualSine.py
+++ b/tests/unit_tests/test_ustar_cp/test_fcEqnAnnualSine.py
@@ -48,4 +48,4 @@ def test_fcEqnAnnualSine_edge_cases(test_engine, b, t, expected, request):
     result = test_engine.fcEqnAnnualSine(b_input, t_input)
 
     # Verify result
-    assert test_engine.equal(result, expected)
+    assert test_engine.equal(result, test_engine.convert(expected))


### PR DESCRIPTION
Tests for fcEqnAnnualSine were failing. Converting the expected result fixes it. Both MATLAB and Python okay now.